### PR TITLE
feat: 實作 Log 系統自動記錄診斷結果

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 results/*.txt
 results/*.log
+logs/
 .DS_Store
 *.swp

--- a/scripts/advanced/github_network_diagnostic_v2.sh
+++ b/scripts/advanced/github_network_diagnostic_v2.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# 載入 log 系統
+source "$(dirname "$0")/../utils/log.sh"
+start_log "$0"
+
 # 顏色定義
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/scripts/advanced/video_streaming_test.sh
+++ b/scripts/advanced/video_streaming_test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# 載入 log 系統
+source "$(dirname "$0")/../utils/log.sh"
+start_log "$0"
+
 # 顏色定義
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/scripts/advanced/warp_route_test.sh
+++ b/scripts/advanced/warp_route_test.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# 載入 log 系統
+source "$(dirname "$0")/../utils/log.sh"
+start_log "$0"
+
 # 顏色定義
 RED='\033[0;31m'
 GREEN='\033[0;32m'

--- a/scripts/basic/20250910-test-github-net.sh
+++ b/scripts/basic/20250910-test-github-net.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# 載入 log 系統
+source "$(dirname "$0")/../utils/log.sh"
+start_log "$0"
+
 echo "=== GitHub 網路診斷 ==="
 echo "時間: $(date)"
 echo ""

--- a/scripts/utils/log.sh
+++ b/scripts/utils/log.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Log 系統工具函數
+# 用途：為診斷工具提供統一的 log 記錄功能
+
+# 取得專案根目錄
+LOG_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/logs/$(date '+%Y%m%d')"
+
+# 建立 log 目錄
+mkdir -p "$LOG_DIR"
+
+# 開始記錄函數
+start_log() {
+    local script_path=$1
+    local script_name=$(basename "$script_path" .sh)
+    
+    # 產生 log 檔案路徑：script_name_HHMMSS.log
+    LOG_FILE="$LOG_DIR/${script_name}_$(date '+%H%M%S').log"
+    
+    # 使用 tee 同時輸出到終端和檔案
+    exec > >(tee -a "$LOG_FILE")
+    exec 2>&1
+    
+    # 顯示 log 檔案位置
+    echo "Log 記錄: $LOG_FILE"
+    echo "開始時間: $(date '+%Y-%m-%d %H:%M:%S')"
+    echo "========================================="
+    echo ""
+}


### PR DESCRIPTION
## 概述

實作自動 Log 系統，讓所有網路診斷工具執行時同時輸出到終端和 log 檔案，便於後續分析和問題追蹤。

## 變更內容

### 新增功能
- ✅ 建立 `scripts/utils/log.sh` 統一 log 工具函數
- ✅ 自動建立按日期分類的目錄結構：`logs/YYYYMMDD/`
- ✅ 檔案命名包含時間戳：`script_name_HHMMSS.log`
- ✅ 使用 `tee` 實現同時輸出到終端和檔案

### 修改腳本
已為以下 4 個診斷腳本加入 log 功能：
- `scripts/basic/20250910-test-github-net.sh`
- `scripts/advanced/github_network_diagnostic_v2.sh`
- `scripts/advanced/video_streaming_test.sh`
- `scripts/advanced/warp_route_test.sh`

### 其他變更
- 更新 `.gitignore` 排除 `logs/` 目錄

## 測試結果

✅ 已測試驗證：
- 基本診斷腳本正常產生 log 檔案
- 進階診斷腳本正常產生 log 檔案
- 終端輸出不受影響
- 檔案記錄完整包含所有輸出和錯誤訊息

## Log 檔案範例
```
logs/20250910/
├── 20250910-test-github-net_180256.log
└── github_network_diagnostic_v2_222119.log
```

## 相關 Issue
Related to #2 - 實作 Log 系統：自動記錄診斷工具執行結果

> 註：此 PR 完成了 Issue #2 的所有實作項目，但保留 Issue 開啟以便追蹤後續可能的改進或調整。